### PR TITLE
Fix: changed type of size and offset to off_t

### DIFF
--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -117,11 +117,11 @@ JS_FN(mmap_map) {
     // Offset and advise are optional
 
     constexpr void* hinted_address  = nullptr;  // Just making things uber-clear...
-    const size_t    size            = static_cast<size_t>(get_v<int>(info[0]));
+    const size_t    size            = static_cast<size_t>(get_v<off_t>(info[0]));
     const int       protection      = get_v<int>(info[1]);
     const int       flags           = get_v<int>(info[2]);
     const int       fd              = get_v<int>(info[3]);
-    const size_t    offset          = static_cast<size_t>(get_v<int>(info[4], 0));
+    const off_t     offset          = get_v<off_t>(info[4], 0);
     const int       advise          = get_v<int>(info[5], 0);
 
     char* data = static_cast<char*>( mmap( hinted_address, size, protection, flags, fd, offset) );


### PR DESCRIPTION
As the parameters for map read from JavaScript where explicitely set to int only 2GB could be used for either size or offset even on a 64bit system. This limits using mmap-io's access to memory areas mapped higher into the address space.

The type off_t automatically maps to a int32_t on 32 bit systems and int64_t on 64 bit therefore I changed int in the code to off_t and we'll automatically get the right int size. It's not a full fix as the better suited size_t maps to unsigned: So on 32bit systems the 2GB limit is still in place but on 64bit this covers 8 Exabytes of address space. Unfortunately the NAN library does not contain an unsigned type for 64bit so off_t is the best we can do.
