### PR TITLE
Revert "Fix: changed type of size and offset to off_t"

### DIFF
--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -117,11 +117,11 @@ JS_FN(mmap_map) {
     // Offset and advise are optional
 
     constexpr void* hinted_address  = nullptr;  // Just making things uber-clear...
-    const size_t    size            = static_cast<size_t>(get_v<off_t>(info[0]));
+    const size_t    size            = static_cast<size_t>(get_v<int>(info[0]));
     const int       protection      = get_v<int>(info[1]);
     const int       flags           = get_v<int>(info[2]);
     const int       fd              = get_v<int>(info[3]);
-    const off_t     offset          = get_v<off_t>(info[4], 0);
+    const size_t    offset          = static_cast<size_t>(get_v<int>(info[4], 0));
     const int       advise          = get_v<int>(info[5], 0);
 
 #ifdef _WIN32


### PR DESCRIPTION
Reverts Widdershin/mmap-io#1

Unfortunately this has build issues on Windows I don't have time to look into right now.

Namely:

```
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
  mmap-io.cc
  win_delay_load_hook.cc
c:\users\nick\projects\mmap-io\src\mmap-io.cc(88): error C2672: 'Nan::To': no matching overloaded function found [C:\Users\Nick\Proj
ects\mmap-io\build\mmap_io.vcxproj]
  c:\users\nick\projects\mmap-io\src\mmap-io.cc(121): note: see reference to function template instantiation 'T get_v<off_t,v8::Loca
  l<v8::Value>>(VT)' being compiled
          with
          [
              T=off_t,
              VT=v8::Local<v8::Value>
          ]
c:\users\nick\projects\mmap-io\src\mmap-io.cc(88): error C2770: invalid explicit template argument(s) for 'imp::ToFactory<T>::return
_t Nan::To(v8::Local<v8::Value>)' [C:\Users\Nick\Projects\mmap-io\build\mmap_io.vcxproj]
  c:\users\nick\projects\mmap-io\node_modules\nan\nan_converters.h(61): note: see declaration of 'Nan::To'
c:\users\nick\projects\mmap-io\src\mmap-io.cc(96): error C2672: 'Nan::To': no matching overloaded function found [C:\Users\Nick\Proj
ects\mmap-io\build\mmap_io.vcxproj]
  c:\users\nick\projects\mmap-io\src\mmap-io.cc(125): note: see reference to function template instantiation 'T get_v<off_t,v8::Loca
  l<v8::Value>>(VT,T)' being compiled
          with
          [
              T=off_t,
              VT=v8::Local<v8::Value>
          ]
c:\users\nick\projects\mmap-io\src\mmap-io.cc(96): error C2770: invalid explicit template argument(s) for 'imp::ToFactory<T>::return
_t Nan::To(v8::Local<v8::Value>)' [C:\Users\Nick\Projects\mmap-io\build\mmap_io.vcxproj]
  c:\users\nick\projects\mmap-io\node_modules\nan\nan_converters.h(61): note: see declaration of 'Nan::To'
```

Happy to reinclude this PR if these issues can be addressed.